### PR TITLE
Update rename-ssd-cache.adoc

### DIFF
--- a/commands-a-z/rename-ssd-cache.adoc
+++ b/commands-a-z/rename-ssd-cache.adoc
@@ -22,7 +22,7 @@ To execute this command on an E2800 or E5700 storage array, you must have the Su
 == Syntax
 [subs=+macros]
 ----
-set ssdCache pass:quotes[[_old_ssdCacheName_] userLabel=pass:quotes[_"new_ssdCacheName_"]
+set ssdCache pass:quotes[[_old_ssdCacheName_]] userLabel=pass:quotes[_"new_ssdCacheName_"]
 ----
 
 == Parameter


### PR DESCRIPTION
_old_ssdCacheName_ was missing a closing bracket in the published form. The command does not run without the closing bracket.